### PR TITLE
shiny observers

### DIFF
--- a/R/robservable.R
+++ b/R/robservable.R
@@ -1,15 +1,15 @@
 #' Display an Observable notebook as HTML widget
 #'
 #'
-#' @param notebook The notebook id, such as "@d3/bar-chart".
-#' @param cell character vector of cell names to be rendered. If NULL,  the whole notebook is rendered.
-#' @param hide character vector of cell names in `cell` to be hidden in the output.
+#' @param notebook The notebook id, such as "@d3/bar-chart"
+#' @param cell The name of the cell to be rendered. If NULL,  the whole notebook is rendered
 #' @param input A named list of cells to be updated.
-#' @param observers A vector of character strings representing variables in observable that
-#'   you would like to set as input values in Shiny.
-#' @param width htmlwidget width.
-#' @param height htmlwidget height.
-#' @param elementId optional manual widget HTML id.
+#' @param observers A vector or named list of character strings representing variables in observable that
+#'   you would like to set as input values in Shiny.  If provided a named list, then the Shiny input
+#'   will be named with the name from the list rather than the observable variable name.
+#' @param width htmlwidget width
+#' @param height htmlwidget height
+#' @param elementId optional manual widget HTML id
 #'
 #' @details
 #' Values passed in `input_df` are converted using the JavaScript function `HTMLWidgets.dataframeToD3`.
@@ -43,15 +43,14 @@
 #' @export
 #'
 robservable <- function(
-  notebook, cell = NULL, hide = NULL,
-  input = NULL, observers = NULL,
+  notebook, cell = NULL, input = NULL,
+  observers = NULL,
   width = NULL, height = NULL, elementId = NULL
 ) {
 
-  x <- list(
+  x = list(
     notebook = notebook,
     cell = cell,
-    hide = hide,
     input = input,
     observers = observers
   )

--- a/R/robservable.R
+++ b/R/robservable.R
@@ -1,15 +1,16 @@
 #' Display an Observable notebook as HTML widget
 #'
 #'
-#' @param notebook The notebook id, such as "@d3/bar-chart"
-#' @param cell The name of the cell to be rendered. If NULL,  the whole notebook is rendered
+#' @param notebook The notebook id, such as "@d3/bar-chart".
+#' @param cell character vector of cell names to be rendered. If NULL,  the whole notebook is rendered.
+#' @param hide character vector of cell names in `cell` to be hidden in the output.
 #' @param input A named list of cells to be updated.
 #' @param observers A vector or named list of character strings representing variables in observable that
 #'   you would like to set as input values in Shiny.  If provided a named list, then the Shiny input
 #'   will be named with the name from the list rather than the observable variable name.
-#' @param width htmlwidget width
-#' @param height htmlwidget height
-#' @param elementId optional manual widget HTML id
+#' @param width htmlwidget width.
+#' @param height htmlwidget height.
+#' @param elementId optional manual widget HTML id.
 #'
 #' @details
 #' Values passed in `input_df` are converted using the JavaScript function `HTMLWidgets.dataframeToD3`.
@@ -43,14 +44,15 @@
 #' @export
 #'
 robservable <- function(
-  notebook, cell = NULL, input = NULL,
-  observers = NULL,
+  notebook, cell = NULL, hide = NULL,
+  input = NULL, observers = NULL,
   width = NULL, height = NULL, elementId = NULL
 ) {
 
-  x = list(
+  x <- list(
     notebook = notebook,
     cell = cell,
+    hide = hide,
     input = input,
     observers = observers
   )

--- a/examples/shiny_observer.R
+++ b/examples/shiny_observer.R
@@ -36,8 +36,8 @@ server <- function(input, output) {
 
     point <- reactive({
         cbind(
-            input$map_input_observer_worldMap1[1],
-            input$map_input_observer_worldMap1[2]
+            input$map_input_worldMap1[1],
+            input$map_input_worldMap1[2]
         )
     })
 

--- a/inst/htmlwidgets/robservable.js
+++ b/inst/htmlwidgets/robservable.js
@@ -99,7 +99,7 @@ HTMLWidgets.widget({
                                             //console.log(value, name)
                                             if (HTMLWidgets.shinyMode) {
                                                 Shiny.setInputValue(
-                                                    name,
+                                                    name.replace(/_observer/, ""),
                                                     value
                                                 );
                                             }

--- a/inst/htmlwidgets/robservable.js
+++ b/inst/htmlwidgets/robservable.js
@@ -28,20 +28,8 @@ HTMLWidgets.widget({
 
     name: 'robservable',
     type: 'output',
-    inspector: class VariableInspector {
-        fulfilled(value, name) {
-            console.log(value, name)
-            if (HTMLWidgets.shinyMode) {
-                Shiny.setInputValue(
-                    name,
-                    value
-                );
-            }
-        }
-    },
 
     factory: function (el, width, height) {
-        const inspector = new this.inspector;
 
         let module = null;
 
@@ -99,15 +87,28 @@ HTMLWidgets.widget({
                             document.querySelector('body').style["width"] = "auto";
                         }
 
-                    }
 
-                    // If in Shiny mode and observers are set then set these up in Observable
-                    if (x.observers !== null) {
-                        // if only one observer then might not be an array so force to array
-                        x.observers = !Array.isArray(x.observers) ? [x.observers] : x.observers;
-                        x.observers.forEach((d, i) => {
-                            main.variable(inspector).define(el.id + '_observer_' + d, [d], (x) => x);
-                        });
+                        // If in Shiny mode and observers are set then set these up in Observable
+                        if (x.observers !== null) {
+                            // if only one observer then might not be an array so force to array
+                            x.observers = !Array.isArray(x.observers) ? [x.observers] : x.observers;
+                            x.observers.forEach((d, i) => {
+                                main
+                                    .variable({
+                                        fulfilled(value, name) {
+                                            //console.log(value, name)
+                                            if (HTMLWidgets.shinyMode) {
+                                                Shiny.setInputValue(
+                                                    name,
+                                                    value
+                                                );
+                                            }
+                                        }
+                                    })
+                                    .define(el.id + '_observer_' + d, [d], (x) => x);
+                            });
+                        }
+
                     }
 
                     // Update inputs

--- a/inst/htmlwidgets/robservable.js
+++ b/inst/htmlwidgets/robservable.js
@@ -90,23 +90,42 @@ HTMLWidgets.widget({
 
                         // If in Shiny mode and observers are set then set these up in Observable
                         if (x.observers !== null) {
-                            // if only one observer then might not be an array so force to array
-                            x.observers = !Array.isArray(x.observers) ? [x.observers] : x.observers;
-                            x.observers.forEach((d, i) => {
-                                main
-                                    .variable({
-                                        fulfilled(value, name) {
-                                            //console.log(value, name)
-                                            if (HTMLWidgets.shinyMode) {
-                                                Shiny.setInputValue(
-                                                    name.replace(/_observer/, ""),
-                                                    value
-                                                );
+                            // if only one observer and string then force to array
+                            x.observers = !Array.isArray(x.observers) && typeof(x.observers) === "string" ? [x.observers] : x.observers;
+                            if(Array.isArray(x.observers)) {
+                                x.observers.forEach((d, i) => {
+                                    main
+                                        .variable({
+                                            fulfilled(value, name) {
+                                                console.log(value, name)
+                                                if (HTMLWidgets.shinyMode) {
+                                                    Shiny.setInputValue(
+                                                        name.replace(/_observer/, ""),
+                                                        value
+                                                    );
+                                                }
                                             }
-                                        }
-                                    })
-                                    .define(el.id + '_observer_' + d, [d], (x) => x);
-                            });
+                                        })
+                                        .define(el.id + '_observer_' + d, [d], (x) => x);
+                                });
+                            }
+                            if(!Array.isArray(x.observers) && typeof(x.observers) === "object") {
+                                Object.keys(x.observers).forEach((ky) => {
+                                    main
+                                        .variable({
+                                            fulfilled(value, name) {
+                                                console.log(value, name)
+                                                if (HTMLWidgets.shinyMode) {
+                                                    Shiny.setInputValue(
+                                                        name.replace(/_observer/, ""),
+                                                        value
+                                                    );
+                                                }
+                                            }
+                                        })
+                                        .define(el.id + '_observer_' + ky, [x.observers[ky]], (x) => x);
+                                })
+                            }
                         }
 
                     }


### PR DESCRIPTION
As discussed in https://github.com/juba/robservable/issues/5,

- inspector as plain object instead of class
- make sure observers are not duplicated when robservable updated instead of rendered
- remove `_observer` from Shiny input to simplify
- allow named list of observers


