### PR TITLE
Better default width and height handling

### DIFF
--- a/R/robservable.R
+++ b/R/robservable.R
@@ -48,6 +48,21 @@ robservable <- function(
   width = NULL, height = NULL, elementId = NULL
 ) {
 
+  # Pass width and height as inputs
+  if (!is.null(width)) {
+    if (!is.null(input$width)) {
+      warning("input$width overriden by width argument")
+    }
+    input$width = width
+  }
+  if (!is.null(height)) {
+    if (!is.null(input$height)) {
+      warning("input$height overriden by height argument")
+    }
+    input$height = height
+  }
+
+
   x <- list(
     notebook = notebook,
     cell = cell,
@@ -56,10 +71,6 @@ robservable <- function(
     observers = observers
   )
   attr(x, 'TOJSON_ARGS') <- list(dataframe = "rows")
-
-  if (!is.null(width)) {
-    x$robservable_width <- width
-  }
 
 
   htmlwidgets::createWidget(

--- a/R/robservable.R
+++ b/R/robservable.R
@@ -7,9 +7,8 @@
 #' @param input A named list of cells to be updated.
 #' @param observers A vector of character strings representing variables in observable that
 #'   you would like to set as input values in Shiny.
-#' @param keep_notebook_height if FALSE (default), replace any existing notebook \code{height} variable 
-#'   with either the \code{height} value of \code{input}, or the height of the widget root HTML element.
-#'   If TRUE, keep original notebook \{height} variable value.
+#' @param update_height if TRUE (default) and input$height is not defined, replace its value with the height of the widget root HTML element. Note there will not always be such a cell in every notebook. Set it to FALSE to always keep the notebook value.
+#' @param update_width if TRUE (default) and input$width is not defined, replace its value with the width of the widget root HTML element. Set it to FALSE to always keep the notebook or the Observable stdlib value.
 #' @param width htmlwidget width.
 #' @param height htmlwidget height.
 #' @param elementId optional manual widget HTML id.
@@ -25,13 +24,13 @@
 #' ## Display a notebook cell
 #' robservable(
 #'   "@d3/bar-chart",
-#'   cell= "chart"
+#'   cell = "chart"
 #' )
 #'
 #' ## Change cells data with input
 #' robservable(
 #'   "@d3/bar-chart",
-#'   cell= "chart",
+#'   cell = "chart",
 #'   input = list(color = "red", height = 700)
 #' )
 #'
@@ -40,34 +39,19 @@
 #' names(df) <- c("name", "value")
 #' robservable(
 #'   "@d3/horizontal-bar-chart",
-#'   cell= "chart",
+#'   cell = "chart",
 #'   input = list(data = df)
 #' )
 #' }
 #' @export
 #'
 robservable <- function(
-  notebook, cell = NULL, hide = NULL,
-  input = NULL, observers = NULL,
-  keep_notebook_height = FALSE,
-  width = NULL, height = NULL, 
-  elementId = NULL
-) {
-
-  # Pass width and height as inputs
-  if (!is.null(width)) {
-    if (!is.null(input$width)) {
-      warning("input$width overriden by width argument")
-    }
-    input$width <- width
-  }
-  if (!is.null(height)) {
-    if (!is.null(input$height)) {
-      warning("input$height overriden by height argument")
-    }
-    input$height <- height
-  }
-
+                        notebook, cell = NULL, hide = NULL,
+                        input = NULL, observers = NULL,
+                        update_height = TRUE,
+                        update_width = TRUE,
+                        width = NULL, height = NULL,
+                        elementId = NULL) {
 
   x <- list(
     notebook = notebook,
@@ -75,17 +59,18 @@ robservable <- function(
     hide = hide,
     input = input,
     observers = observers,
-    keep_notebook_height = keep_notebook_height
+    update_height = update_height,
+    update_width = update_width
   )
-  attr(x, 'TOJSON_ARGS') <- list(dataframe = "rows")
+  attr(x, "TOJSON_ARGS") <- list(dataframe = "rows")
 
 
   htmlwidgets::createWidget(
     x,
-    name = 'robservable',
+    name = "robservable",
     width = width,
     height = height,
-    package = 'robservable',
+    package = "robservable",
     elementId = elementId
   )
 }
@@ -123,13 +108,15 @@ to_js_date <- function(date) {
 #' @name robservable-shiny
 #'
 #' @export
-robservableOutput <- function(outputId, width = '100%', height = '400px'){
-  htmlwidgets::shinyWidgetOutput(outputId, 'robservable', width, height, package = 'robservable')
+robservableOutput <- function(outputId, width = "100%", height = "400px") {
+  htmlwidgets::shinyWidgetOutput(outputId, "robservable", width, height, package = "robservable")
 }
 
 #' @rdname robservable-shiny
 #' @export
 renderRobservable <- function(expr, env = parent.frame(), quoted = FALSE) {
-  if (!quoted) { expr <- substitute(expr) } # force quoted
+  if (!quoted) {
+    expr <- substitute(expr)
+  } # force quoted
   htmlwidgets::shinyRenderWidget(expr, robservableOutput, env, quoted = TRUE)
 }

--- a/R/robservable.R
+++ b/R/robservable.R
@@ -7,6 +7,9 @@
 #' @param input A named list of cells to be updated.
 #' @param observers A vector of character strings representing variables in observable that
 #'   you would like to set as input values in Shiny.
+#' @param keep_notebook_height if FALSE (default), replace any existing notebook \code{height} variable 
+#'   with either the \code{height} value of \code{input}, or the height of the widget root HTML element.
+#'   If TRUE, keep original notebook \{height} variable value.
 #' @param width htmlwidget width.
 #' @param height htmlwidget height.
 #' @param elementId optional manual widget HTML id.
@@ -46,7 +49,9 @@
 robservable <- function(
   notebook, cell = NULL, hide = NULL,
   input = NULL, observers = NULL,
-  width = NULL, height = NULL, elementId = NULL
+  keep_notebook_height = FALSE,
+  width = NULL, height = NULL, 
+  elementId = NULL
 ) {
 
   # Pass width and height as inputs
@@ -54,13 +59,13 @@ robservable <- function(
     if (!is.null(input$width)) {
       warning("input$width overriden by width argument")
     }
-    input$width = width
+    input$width <- width
   }
   if (!is.null(height)) {
     if (!is.null(input$height)) {
       warning("input$height overriden by height argument")
     }
-    input$height = height
+    input$height <- height
   }
 
 
@@ -69,7 +74,8 @@ robservable <- function(
     cell = cell,
     hide = hide,
     input = input,
-    observers = observers
+    observers = observers,
+    keep_notebook_height = keep_notebook_height
   )
   attr(x, 'TOJSON_ARGS') <- list(dataframe = "rows")
 

--- a/inst/htmlwidgets/robservable.js
+++ b/inst/htmlwidgets/robservable.js
@@ -120,7 +120,11 @@ class RObservable {
         let input = this.params.input
         input = input === null ? {} : input;
         Object.entries(input).forEach(([key, value]) => {
-            this.main.redefine(key, value);
+            try {
+                this.main.redefine(key, value);
+            } catch (error) {
+                console.warn(`Can't update ${key} variable : ${error.message}`);
+            }
         })
     }
 

--- a/inst/htmlwidgets/robservable.js
+++ b/inst/htmlwidgets/robservable.js
@@ -110,7 +110,6 @@ class RObservable {
         let input = this.params.input
         input = input === null ? {} : input;
         Object.entries(input).forEach(([key, value]) => {
-            if (key == "height" && this.params.keep_notebook_height) return;
             try {
                 this.main.redefine(key, value);
             } catch (error) {

--- a/inst/htmlwidgets/robservable.js
+++ b/inst/htmlwidgets/robservable.js
@@ -110,6 +110,7 @@ class RObservable {
         let input = this.params.input
         input = input === null ? {} : input;
         Object.entries(input).forEach(([key, value]) => {
+            if (key == "height" && this.params.keep_notebook_height) return;
             try {
                 this.main.redefine(key, value);
             } catch (error) {
@@ -141,9 +142,9 @@ HTMLWidgets.widget({
         return {
 
             renderValue(params) {
-                
+
                 params = update_height_width(params, el.height, el.width)
-                
+
                 // Check if module object already created
                 let module = el.module;
                 if (module === undefined || module.params.notebook !== params.notebook) {
@@ -164,7 +165,7 @@ HTMLWidgets.widget({
             },
 
             resize(width, height) {
-                
+
                 // Get params and update width and height
                 el.width = width;
                 el.height = height;

--- a/inst/htmlwidgets/robservable.js
+++ b/inst/htmlwidgets/robservable.js
@@ -148,12 +148,7 @@ HTMLWidgets.widget({
 
             renderValue(params) {
                 
-                if (params.input !== null && params.input.width !== undefined) {
-                    params.input.width = el.width;
-                }
-                if (params.input !== null && params.input.height !== undefined) {
-                    params.input.height = el.height;
-                }
+                params = update_height_width(params, el.height, el.width)
                 
                 // Check if module object already created
                 let module = el.module;
@@ -166,8 +161,9 @@ HTMLWidgets.widget({
                     });
                 } else {
                     // Else, update params
-                    params.update = true;
                     params.observers_variables = module.params.observers_variables;
+                    // Update widgets
+                    params.update = true;
                     el.module.params = params;
                 }
 
@@ -175,17 +171,13 @@ HTMLWidgets.widget({
 
             resize(width, height) {
                 
+                // Get params and update width and height
                 el.width = width;
                 el.height = height;
                 let params = el.module.params;
+                params = update_height_width(params, el.height, el.width)
 
-                if (params.input !== null && params.input.width !== undefined) {
-                    params.input.width = el.width;
-                }
-                if (params.input !== null && params.input.height !== undefined) {
-                    params.input.height = el.height;
-                }
-
+                // Update widgets
                 params.update = true;
                 el.module.params = params;
 

--- a/inst/htmlwidgets/robservable.js
+++ b/inst/htmlwidgets/robservable.js
@@ -11,7 +11,7 @@ class RObservable {
         this._params = params;
         this._params.observers_variables = {};
 
-        let runtime = this.build_runtime();
+        let runtime = new observablehq.Runtime();
         let inspector = this.build_inspector();
         this.main = runtime.module(notebook, inspector);
 
@@ -22,16 +22,6 @@ class RObservable {
         const url = `https://api.observablehq.com/${params.notebook}.js?v=3`;
         let nb = await import(url);
         return new RObservable(el, params, nb.default);
-    }
-
-    // Build observable runtime
-    build_runtime() {
-        // Load Runtime by overriding width stdlib method if fixed width is provided
-        let library = new observablehq.Library;
-        if (this.params.robservable_width !== undefined) {
-            library = Object.assign(library, { width: this.params.robservable_width });
-        }
-        return new observablehq.Runtime(library);
     }
 
     // Build Observable inspector
@@ -137,8 +127,6 @@ class RObservable {
 
 
 
-
-
 HTMLWidgets.widget({
 
     name: 'robservable',
@@ -152,10 +140,20 @@ HTMLWidgets.widget({
             document.querySelector('body').style["width"] = "auto";
         }
 
+        el.width = width;
+        el.height = height;
+
         return {
 
             renderValue(params) {
-
+                
+                if (params.input !== null && params.input.width !== undefined) {
+                    params.input.width = el.width;
+                }
+                if (params.input !== null && params.input.height !== undefined) {
+                    params.input.height = el.height;
+                }
+                
                 // Check if module object already created
                 let module = el.module;
                 if (module === undefined || module.params.notebook !== params.notebook) {
@@ -175,6 +173,21 @@ HTMLWidgets.widget({
             },
 
             resize(width, height) {
+                
+                el.width = width;
+                el.height = height;
+                let params = el.module.params;
+
+                if (params.input !== null && params.input.width !== undefined) {
+                    params.input.width = el.width;
+                }
+                if (params.input !== null && params.input.height !== undefined) {
+                    params.input.height = el.height;
+                }
+
+                params.update = true;
+                el.module.params = params;
+
             }
 
         };

--- a/inst/htmlwidgets/utils.js
+++ b/inst/htmlwidgets/utils.js
@@ -6,15 +6,12 @@ function css_safe(str) {
 
 // Update params height and width
 function update_height_width(params, height, width) {
-    if (params.input === null) {
-        params.input = {width: width, height: height};
-    } else {
-        if (params.input.width === undefined) {
-            params.input.width = width;
-        }
-        if (params.input.height === undefined) {
-            params.input.height = height;
-        }
+    if (params.input === null) params.input = {};
+    if (params.input.width === undefined && params.update_width) {
+        params.input.width = width;
+    }
+    if (params.input.height === undefined && params.update_height) {
+        params.input.height = height;
     }
     return params;
 }

--- a/inst/htmlwidgets/utils.js
+++ b/inst/htmlwidgets/utils.js
@@ -3,3 +3,18 @@ function css_safe(str) {
     str = str.replace(/[!\"#$%&'\(\)\*\+,\.\/:;<=>\?\@\[\\\]\^`\{\|\}~\s]/g, '_');
     return (str);
 }
+
+// Update params height and width
+function update_height_width(params, height, width) {
+    if (params.input === null) {
+        params.input = {width: width, height: height};
+    } else {
+        if (params.input.width === undefined) {
+            params.input.width = width;
+        }
+        if (params.input.height === undefined) {
+            params.input.height = height;
+        }
+    }
+    return params;
+}

--- a/man/robservable.Rd
+++ b/man/robservable.Rd
@@ -10,6 +10,8 @@ robservable(
   hide = NULL,
   input = NULL,
   observers = NULL,
+  update_height = TRUE,
+  update_width = TRUE,
   width = NULL,
   height = NULL,
   elementId = NULL
@@ -27,6 +29,10 @@ robservable(
 \item{observers}{A vector of character strings representing variables in observable that
 you would like to set as input values in Shiny.}
 
+\item{update_height}{if TRUE (default) and input$height is not defined, replace its value with the height of the widget root HTML element. Note there will not always be such a cell in every notebook. Set it to FALSE to always keep the notebook value.}
+
+\item{update_width}{if TRUE (default) and input$width is not defined, replace its value with the width of the widget root HTML element. Set it to FALSE to always keep the notebook or the Observable stdlib value.}
+
 \item{width}{htmlwidget width.}
 
 \item{height}{htmlwidget height.}
@@ -37,20 +43,21 @@ you would like to set as input values in Shiny.}
 Display an Observable notebook as HTML widget
 }
 \details{
-Values passed in `input_df` are converted using the JavaScript function `HTMLWidgets.dataframeToD3`.
+If a data.frame is passed as a cell value in `input`, it will be converted into the format
+expected by `d3` (ie, converted by rows)..
 }
 \examples{
 \donttest{
 ## Display a notebook cell
 robservable(
   "@d3/bar-chart",
-  cell= "chart"
+  cell = "chart"
 )
 
 ## Change cells data with input
 robservable(
   "@d3/bar-chart",
-  cell= "chart",
+  cell = "chart",
   input = list(color = "red", height = 700)
 )
 
@@ -59,7 +66,7 @@ df <- data.frame(table(mtcars$cyl))
 names(df) <- c("name", "value")
 robservable(
   "@d3/horizontal-bar-chart",
-  cell= "chart",
+  cell = "chart",
   input = list(data = df)
 )
 }


### PR DESCRIPTION
Not totally sure about this one yet but after a bit of tinkering I think it may be the best default.

If the new R `update_width` argument is `TRUE` (which is the default), and `input$width` is not defined, then `input$width` is replaced by the actual width of the widget root HTML element. The same for `height`. The replacement is done both at widget creation and when resizing.

`width` will always be an actual notebook value, as it is either defined in the notebook or by the Observable standard library. This is not the case of `height`, but we try to update it anyway (just displaying a JS warning if the variable doesn't exist).

The aim of this is to provide, as much as possible, convenient out of the box behavior when `robservable` is used inside Rmarkdown documents or Shiny applications.