### PR TITLE
render unnamed and more options for hide

### DIFF
--- a/R/robservable.R
+++ b/R/robservable.R
@@ -7,6 +7,7 @@
 #' @param input A named list of cells to be updated.
 #' @param observers A vector of character strings representing variables in observable that
 #'   you would like to set as input values in Shiny.
+#' @param render_unnamed A logical/boolean to render unnamed cells such as \code{html} and \code{md}.
 #' @param update_height if TRUE (default) and input$height is not defined, replace its value with the height of the widget root HTML element. Note there will not always be such a cell in every notebook. Set it to FALSE to always keep the notebook value.
 #' @param update_width if TRUE (default) and input$width is not defined, replace its value with the width of the widget root HTML element. Set it to FALSE to always keep the notebook or the Observable stdlib value.
 #' @param width htmlwidget width.
@@ -48,6 +49,7 @@
 robservable <- function(
                         notebook, cell = NULL, hide = NULL,
                         input = NULL, observers = NULL,
+                        render_unnamed = FALSE,
                         update_height = TRUE,
                         update_width = TRUE,
                         width = NULL, height = NULL,
@@ -59,6 +61,7 @@ robservable <- function(
     hide = hide,
     input = input,
     observers = observers,
+    render_unnamed = render_unnamed,
     update_height = update_height,
     update_width = update_width
   )

--- a/inst/htmlwidgets/robservable.js
+++ b/inst/htmlwidgets/robservable.js
@@ -11,10 +11,19 @@ class RObservable {
         this._params = params;
         this._params.observers_variables = {};
 
+        // set up a Map container to keep track of output <div>
+        this.output_divs = new Map();
+        // set up a counter so we can reference unnamed cells
+        this.num_cells = 0;
+
         let runtime = new observablehq.Runtime();
         let inspector = this.build_inspector();
         this.main = runtime.module(notebook, inspector);
 
+        // if whole notebook is rendered hide cells if user has requested
+        if (this.params.cell === null && this.params.hide !== null) {
+            this.hide_cells();
+        }
     }
 
     // async builder to dynamically import notebook module
@@ -27,13 +36,32 @@ class RObservable {
     // Build Observable inspector
     build_inspector() {
         if (this.params.cell !== null) {
-            // If output is one or several cells
-            let output_divs = this.create_output_divs(this.el, this.params);
+            const cell = !Array.isArray(this.params.cell) ? [this.params.cell] : this.params.cell;
 
             return (name) => {
-                if (this.params.cell.includes(name)) {
-                    return new observablehq.Inspector(output_divs.get(name));
+                let name_safe = "";
+                let div;
+
+                if (cell.includes(name)) {
+                    div = this.create_output_div(name);
+                    return new observablehq.Inspector(div);
                 }
+                if (
+                    this.params.render_unnamed === true &&
+                    (typeof(name) === "undefined" || name === "") &&
+                    // num_cell increments so check to see if user included matching number
+                    //   check both String and numeric since R will convert to character
+                    //   if in a vector that includes any character cell names
+                    (cell.includes(this.num_cells) || cell.includes(String(this.num_cells)))
+                )
+                {
+                    // will not have a name so call unnamed-1
+                    //   so we/user can reference later
+                    //   this is not ideal but hopefully better than nothing
+                    div = this.create_output_div();
+                    return new observablehq.Inspector(div);
+                }
+                this.num_cells++;
             }
         } else {
             // If output is the whole notebook
@@ -54,24 +82,37 @@ class RObservable {
         this.update_variables();
     }
 
-    // Create the <div> elements for each cell to render
-    create_output_divs() {
+    // Create the <div> elements for each cell to render and append to el
+    create_output_div(name) {
+        const num = this.num_cells;
+        let name_safe = (typeof(name) === "undefined" || name === "") ?
+            css_safe("unnamed-" + this.num_cells) :
+            css_safe(name);
 
-        const cell = !Array.isArray(this.params.cell) ? [this.params.cell] : this.params.cell;
         const hide = !Array.isArray(this.params.hide) ? [this.params.hide] : this.params.hide;
 
-        let output_divs = new Map();
-        cell.forEach(name => {
-            let div = document.createElement("div");
-            div.className = css_safe(name);
-            // hide cell if its name is in params.hide
-            if (hide.includes(name)) div.style["display"] = "none";
-            this.el.appendChild(div);
-            output_divs.set(name, div);
-        })
-        return output_divs;
+        let div = document.createElement("div");
+        div.className = name_safe;
+        if(hide.includes(name) || hide.includes(num) || hide.includes(String(num))) {
+            div.style.display = "none";
+        }
+        this.el.appendChild(div);
+        // add to our output_divs tracker
+        this.output_divs.set(name, div);
+        // increment counter
+        this.num_cells ++;
+        return div;
     }
 
+    hide_cells() {
+        const hide = !Array.isArray(this.params.hide) ? [this.params.hide] : this.params.hide;
+        const cells = this.el.querySelectorAll(".observablehq");
+        hide.forEach(num => {
+            try {
+              cells[num].style.display = "none";
+            } catch(e) {}
+        });
+    }
 
     // Add an observer on a notebook variable that sync its value to a Shiny input
     add_observer(variable) {

--- a/man/robservable.Rd
+++ b/man/robservable.Rd
@@ -10,6 +10,7 @@ robservable(
   hide = NULL,
   input = NULL,
   observers = NULL,
+  render_unnamed = FALSE,
   update_height = TRUE,
   update_width = TRUE,
   width = NULL,
@@ -28,6 +29,8 @@ robservable(
 
 \item{observers}{A vector of character strings representing variables in observable that
 you would like to set as input values in Shiny.}
+
+\item{render_unnamed}{A logical/boolean to render unnamed cells such as \code{html} and \code{md}.}
 
 \item{update_height}{if TRUE (default) and input$height is not defined, replace its value with the height of the widget root HTML element. Note there will not always be such a cell in every notebook. Set it to FALSE to always keep the notebook value.}
 


### PR DESCRIPTION
As discussed in #21 I assembled this pull request to provide users an ability to render unnamed cells and also allow a user more options to hide cells.  Here is some code to test and demonstrate the new functionality.

```
library(robservable)
library(htmltools)

browsable(tagList(
  div(
    "# should produce just one pretty vertical sankey",
    robservable(
      "@tomshanley/vertical-sankey-with-elegant-links-to-entry-and-exit-nodes",
      cell = "chart",
      render_unnamed = FALSE,
      height = "100%"
    )
  ),
  div(
    "# should produce just one pretty vertical sankey even though render_unnamed = TRUE
    #   since we did not specify cell",
    robservable(
      "@tomshanley/vertical-sankey-with-elegant-links-to-entry-and-exit-nodes",
      cell = "chart",
      render_unnamed = TRUE,
      height = "100%"
    )
  ),
  div(
    "# should produce entire notebook regardless of render_unnamed",
    robservable(
      "@tomshanley/vertical-sankey-with-elegant-links-to-entry-and-exit-nodes",
      height = "100%"
    )
  ),
  div(
    "# should only show pretty sankey since render_unnamed = FALSE",
    robservable(
      "@tomshanley/vertical-sankey-with-elegant-links-to-entry-and-exit-nodes",
      cell = c("chart", 0, 2, 3),
      render_unnamed = FALSE,
      height = "100%"
    )
  ),
  div(
    "# should show title and description prior to pretty sankey",
    robservable(
      "@tomshanley/vertical-sankey-with-elegant-links-to-entry-and-exit-nodes",
      cell = c("chart", 0, 2, 4, 5),
      render_unnamed = TRUE,
      height = "100%"
    )
  ),
  div(
    "# should just show title with first sentence because we hide description prior to pretty sankey",
    robservable(
      "@tomshanley/vertical-sankey-with-elegant-links-to-entry-and-exit-nodes",
      cell = c("chart", 0, 2, 4),
      hide = c(2, 4),
      render_unnamed = TRUE,
      height = "100%"
    )
  ),
  div(
    "# and another one to demonstrate why I think we should allow hide even with cell is not specified",
    robservable(
      "@tomshanley/vertical-sankey-with-elegant-links-to-entry-and-exit-nodes",
      # I think a user should be able to specify hide by number and name
      # even if cell is unspecified (meaning all notebook rendered)
      hide = 2:24,
      height = "100%"
    )
  ),
  div(
    "# just a neat little example demonstrating how user can hide",
    robservable(
      "@radames/custom-audio-player-with-d3-vue",
      hide = 3:25, # intentionally include numbers > number of cells to hide everything past
      height = "100%"
    )
  ),
))
```

## Questions/discussion

1. Do we even need `render_unnamed` since a user can now request a cell to be included by `index`/number?  I wrote this to only create the `div` for named if name is included in the `cell` argument, but a user might want to refer to a named cell by number as well - easy to change.  In the event that a user wants to show an unnamed cell and includes in the `cell` argument, the cell will not render if `render_unnamed = FALSE`.  This might be confusing and perhaps we should just get rid of `render_unnamed` altogether.  Old examples will still work regardless of our choice, so there is no breaking change to the API. 
1. Zero-based index - I wrote with zero-based indexing but R users are usually accustomed to one-based indexing.  Do you have a preference?
1. `hide` currently only works when a user also specifies `cell`.  However, a user might want to render an entire notebook to make sure all dependencies are available.  With this pull, a user can request `hide` as before with a named cell(s), but in addition if `cell` is not specified, then a user can provides index numbers to hide.  I demonstrated this in the last two blocks of the example above.  I wrote this to be robust if a user provides an index greater than the number of cells, so that a lazy user could just do something like `4:100` to hide everything after `4`.  Should we also allow a user to hide by `name` when rendering a whole notebook?

As always I love `robservable`, and everything I do is for fun, experimentation, and discussion, so feel free to scrap any or all of the above.