### PR TITLE
remove render_unnamed and one-based index

### DIFF
--- a/R/robservable.R
+++ b/R/robservable.R
@@ -7,7 +7,6 @@
 #' @param input A named list of cells to be updated.
 #' @param observers A vector of character strings representing variables in observable that
 #'   you would like to set as input values in Shiny.
-#' @param render_unnamed A logical/boolean to render unnamed cells such as \code{html} and \code{md}.
 #' @param update_height if TRUE (default) and input$height is not defined, replace its value with the height of the widget root HTML element. Note there will not always be such a cell in every notebook. Set it to FALSE to always keep the notebook value.
 #' @param update_width if TRUE (default) and input$width is not defined, replace its value with the width of the widget root HTML element. Set it to FALSE to always keep the notebook or the Observable stdlib value.
 #' @param width htmlwidget width.
@@ -49,7 +48,6 @@
 robservable <- function(
                         notebook, cell = NULL, hide = NULL,
                         input = NULL, observers = NULL,
-                        render_unnamed = FALSE,
                         update_height = TRUE,
                         update_width = TRUE,
                         width = NULL, height = NULL,
@@ -61,7 +59,6 @@ robservable <- function(
     hide = hide,
     input = input,
     observers = observers,
-    render_unnamed = render_unnamed,
     update_height = update_height,
     update_width = update_width
   )

--- a/inst/htmlwidgets/robservable.js
+++ b/inst/htmlwidgets/robservable.js
@@ -54,7 +54,6 @@ class RObservable {
                     return new observablehq.Inspector(div);
                 }
                 if (
-                    this.params.render_unnamed === true &&
                     (typeof(name) === "undefined" || name === "") &&
                     // num_cell increments so check to see if user included matching number
                     //   check both String and numeric since R will convert to character

--- a/inst/htmlwidgets/robservable.js
+++ b/inst/htmlwidgets/robservable.js
@@ -14,7 +14,7 @@ class RObservable {
         // set up a Map container to keep track of output <div>
         this.output_divs = new Map();
         // set up a counter so we can reference unnamed cells
-        this.num_cells = 0;
+        this.num_cells = 1;
 
         let runtime = new observablehq.Runtime();
         let inspector = this.build_inspector();

--- a/man/robservable.Rd
+++ b/man/robservable.Rd
@@ -10,7 +10,6 @@ robservable(
   hide = NULL,
   input = NULL,
   observers = NULL,
-  render_unnamed = FALSE,
   update_height = TRUE,
   update_width = TRUE,
   width = NULL,
@@ -29,8 +28,6 @@ robservable(
 
 \item{observers}{A vector of character strings representing variables in observable that
 you would like to set as input values in Shiny.}
-
-\item{render_unnamed}{A logical/boolean to render unnamed cells such as \code{html} and \code{md}.}
 
 \item{update_height}{if TRUE (default) and input$height is not defined, replace its value with the height of the widget root HTML element. Note there will not always be such a cell in every notebook. Set it to FALSE to always keep the notebook value.}
 


### PR DESCRIPTION
This pull amends #23 #21 to remove the `render_unnamed` argument and use 1-based indexing since we are in `R`.

I changed the examples and included below.

```
library(robservable)
library(htmltools)

browsable(tagList(
  div(
    "# should produce just one pretty vertical sankey",
    robservable(
      "@tomshanley/vertical-sankey-with-elegant-links-to-entry-and-exit-nodes",
      cell = "chart",
      height = "100%"
    )
  ),
  div(
    "# should produce entire notebook
    robservable(
      "@tomshanley/vertical-sankey-with-elegant-links-to-entry-and-exit-nodes",
      height = "100%"
    )
  ),
  div(
    "# should show title and description prior to pretty sankey",
    robservable(
      "@tomshanley/vertical-sankey-with-elegant-links-to-entry-and-exit-nodes",
      cell = c("chart", 1, 3, 5, 6),
      height = "100%"
    )
  ),
  div(
    "# should just show title with first sentence because we hide description prior to pretty sankey",
    robservable(
      "@tomshanley/vertical-sankey-with-elegant-links-to-entry-and-exit-nodes",
      cell = c("chart", 1, 3, 5),
      hide = c(3, 5),
      height = "100%"
    )
  ),
  div(
    "# and another one to demonstrate why I think we should allow hide even with cell is not specified",
    robservable(
      "@tomshanley/vertical-sankey-with-elegant-links-to-entry-and-exit-nodes",
      # I think a user should be able to specify hide by number and name
      # even if cell is unspecified (meaning all notebook rendered)
      hide = 3:25,
      height = "100%"
    )
  ),
  div(
    "# just a neat little example demonstrating how user can hide",
    robservable(
      "@radames/custom-audio-player-with-d3-vue",
      hide = 4:25, # intentionally include numbers > number of cells to hide everything past
      height = "100%"
    )
  )
))
```